### PR TITLE
Add PAMAP2 data ingestion helpers and CLI experiment

### DIFF
--- a/About.md
+++ b/About.md
@@ -12,3 +12,11 @@ Tsetlin Machines to different problem domains.
   When Matplotlib is available the learning curves are rendered as PNG files;
   otherwise a textual fallback is emitted so the workflow remains runnable
   without network access.
+
+## Research planning notes
+
+- [High-frequency Sensor Benchmark: PAMAP2 Activity Monitoring](docs/research/high_frequency_sensor_plan.md)
+  summarises a high-density wearable dataset with published transformer and
+  LSTM baselines. The note now links to `datasets/pamap2.py` for runtime
+  ingestion/windowing helpers and `examples/pamap2_tsetlin.py` for a CLI
+  experiment that trains the surrogate Tsetlin Machine on PAMAP2 windows.

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,25 @@
+"""Dataset utilities for the Tsetlin time-series prototypes."""
+
+from .pamap2 import (
+    PAMAP2_ARCHIVE_URL,
+    PAMAP2_COLUMN_NAMES,
+    Pamap2WindowDataset,
+    binarize_windows,
+    ensure_pamap2_dataset,
+    list_subject_files,
+    load_pamap2_dataframe,
+    summarise_windows,
+    DEFAULT_SENSOR_COLUMNS,
+)
+
+__all__ = [
+    "PAMAP2_ARCHIVE_URL",
+    "PAMAP2_COLUMN_NAMES",
+    "Pamap2WindowDataset",
+    "binarize_windows",
+    "ensure_pamap2_dataset",
+    "list_subject_files",
+    "load_pamap2_dataframe",
+    "summarise_windows",
+    "DEFAULT_SENSOR_COLUMNS",
+]

--- a/datasets/pamap2.py
+++ b/datasets/pamap2.py
@@ -1,0 +1,398 @@
+"""Utility functions for working with the PAMAP2 activity dataset.
+
+The helpers in this module intentionally avoid downloading or processing the
+full dataset at import time. Instead, they expose composable building blocks
+for scripts that want to fetch the archive on demand, load selected subject
+files, window the time-series signals, and turn the resulting statistics into
+binary feature vectors consumable by a (MultiClass) Tsetlin Machine.
+
+The implementation relies on :mod:`pandas` and :mod:`numpy` for data wrangling.
+Both dependencies are ubiquitous in scientific Python environments, but they
+are not bundled with this repository to keep the prototype lightweight. Scripts
+using this module should declare them as optional extras when necessary.
+"""
+
+from __future__ import annotations
+
+import math
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+from zipfile import ZipFile
+
+import numpy as np
+import pandas as pd
+
+PAMAP2_ARCHIVE_URL = (
+    "https://archive.ics.uci.edu/ml/machine-learning-databases/00231/"
+    "PAMAP2_Dataset.zip"
+)
+"""Location of the official PAMAP2 dataset archive."""
+
+PAMAP2_COLUMN_NAMES: Tuple[str, ...] = (
+    "timestamp",
+    "activity_id",
+    "heart_rate",
+    "hand_temperature",
+    "hand_acc_16g_x",
+    "hand_acc_16g_y",
+    "hand_acc_16g_z",
+    "hand_acc_6g_x",
+    "hand_acc_6g_y",
+    "hand_acc_6g_z",
+    "hand_gyro_x",
+    "hand_gyro_y",
+    "hand_gyro_z",
+    "hand_mag_x",
+    "hand_mag_y",
+    "hand_mag_z",
+    "hand_orientation_w",
+    "hand_orientation_x",
+    "hand_orientation_y",
+    "hand_orientation_z",
+    "chest_temperature",
+    "chest_acc_16g_x",
+    "chest_acc_16g_y",
+    "chest_acc_16g_z",
+    "chest_acc_6g_x",
+    "chest_acc_6g_y",
+    "chest_acc_6g_z",
+    "chest_gyro_x",
+    "chest_gyro_y",
+    "chest_gyro_z",
+    "chest_mag_x",
+    "chest_mag_y",
+    "chest_mag_z",
+    "chest_orientation_w",
+    "chest_orientation_x",
+    "chest_orientation_y",
+    "chest_orientation_z",
+    "ankle_temperature",
+    "ankle_acc_16g_x",
+    "ankle_acc_16g_y",
+    "ankle_acc_16g_z",
+    "ankle_acc_6g_x",
+    "ankle_acc_6g_y",
+    "ankle_acc_6g_z",
+    "ankle_gyro_x",
+    "ankle_gyro_y",
+    "ankle_gyro_z",
+    "ankle_mag_x",
+    "ankle_mag_y",
+    "ankle_mag_z",
+    "ankle_orientation_w",
+    "ankle_orientation_x",
+    "ankle_orientation_y",
+    "ankle_orientation_z",
+)
+"""Ordered feature names according to the dataset documentation."""
+
+DEFAULT_SENSOR_COLUMNS: Tuple[str, ...] = (
+    "heart_rate",
+    "hand_acc_16g_x",
+    "hand_acc_16g_y",
+    "hand_acc_16g_z",
+    "chest_acc_16g_x",
+    "chest_acc_16g_y",
+    "chest_acc_16g_z",
+    "ankle_acc_16g_x",
+    "ankle_acc_16g_y",
+    "ankle_acc_16g_z",
+    "hand_gyro_x",
+    "hand_gyro_y",
+    "hand_gyro_z",
+    "chest_gyro_x",
+    "chest_gyro_y",
+    "chest_gyro_z",
+    "ankle_gyro_x",
+    "ankle_gyro_y",
+    "ankle_gyro_z",
+    "hand_mag_x",
+    "hand_mag_y",
+    "hand_mag_z",
+    "chest_mag_x",
+    "chest_mag_y",
+    "chest_mag_z",
+    "ankle_mag_x",
+    "ankle_mag_y",
+    "ankle_mag_z",
+)
+"""Lightweight default subset of channels for experimentation."""
+
+
+@dataclass
+class Pamap2WindowDataset:
+    """Windowed dataset together with provenance metadata."""
+
+    features: np.ndarray
+    labels: np.ndarray
+    metadata: Mapping[str, object]
+
+
+def ensure_pamap2_dataset(
+    destination_root: Path | str,
+    *,
+    url: str = PAMAP2_ARCHIVE_URL,
+    archive_name: str = "PAMAP2_Dataset.zip",
+) -> Path:
+    """Download and extract the PAMAP2 dataset if it is missing.
+
+    Parameters
+    ----------
+    destination_root:
+        Directory where the archive will be stored and extracted.
+    url:
+        Download location. Defaults to the official UCI mirror.
+    archive_name:
+        Optional override for the archive file name.
+
+    Returns
+    -------
+    Path
+        Path pointing to the extracted dataset directory (``PAMAP2_Dataset``).
+    """
+
+    destination_root = Path(destination_root)
+    destination_root.mkdir(parents=True, exist_ok=True)
+
+    archive_path = destination_root / archive_name
+    extract_path = destination_root / "PAMAP2_Dataset"
+
+    if not archive_path.exists():
+        with urllib.request.urlopen(url) as response, archive_path.open("wb") as handle:
+            chunk_size = 1 << 20  # 1 MiB
+            while True:
+                chunk = response.read(chunk_size)
+                if not chunk:
+                    break
+                handle.write(chunk)
+
+    if not extract_path.exists():
+        with ZipFile(archive_path) as archive:
+            archive.extractall(destination_root)
+
+    return extract_path
+
+
+def list_subject_files(dataset_root: Path | str) -> Mapping[int, Path]:
+    """Return a mapping from subject identifier to ``.dat`` file path."""
+
+    dataset_root = Path(dataset_root)
+    subject_files: Dict[int, Path] = {}
+
+    for folder in ("Protocol", "Optional"):
+        candidate_dir = dataset_root / folder
+        if not candidate_dir.exists():
+            continue
+        for path in sorted(candidate_dir.glob("subject*.dat")):
+            stem = path.stem.replace("subject", "")
+            if not stem.isdigit():
+                continue
+            subject_files[int(stem)] = path
+
+    return subject_files
+
+
+def _read_subject_file(path: Path, *, drop_idle: bool) -> pd.DataFrame:
+    data_frame = pd.read_csv(
+        path,
+        sep=" ",
+        header=None,
+        names=PAMAP2_COLUMN_NAMES,
+        na_values=["-1.000000", "-1.0"],
+        engine="c",
+        comment=None,
+    )
+
+    if drop_idle:
+        data_frame = data_frame[data_frame["activity_id"] != 0]
+
+    return data_frame.reset_index(drop=True)
+
+
+def load_pamap2_dataframe(
+    dataset_root: Path | str,
+    *,
+    subjects: Iterable[int] | None = None,
+    drop_idle: bool = True,
+    columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Load selected subjects into a combined :class:`pandas.DataFrame`.
+
+    Parameters
+    ----------
+    dataset_root:
+        Path returned by :func:`ensure_pamap2_dataset` (the folder containing
+        ``Protocol`` and ``Optional`` recordings).
+    subjects:
+        Iterable of subject identifiers to load. When omitted, all available
+        subject files are used.
+    drop_idle:
+        Whether to remove samples with the ``activity_id`` equal to ``0``.
+    columns:
+        Optional subset of columns to retain (``activity_id`` and ``timestamp``
+        are always preserved).
+    """
+
+    dataset_root = Path(dataset_root)
+    subject_files = list_subject_files(dataset_root)
+
+    if not subject_files:
+        raise FileNotFoundError(
+            f"No PAMAP2 subject files found under {dataset_root}. Did you call "
+            "ensure_pamap2_dataset first?"
+        )
+
+    if subjects is None:
+        selected_subjects = sorted(subject_files)
+    else:
+        selected_subjects = sorted(int(identifier) for identifier in subjects)
+
+    frames: List[pd.DataFrame] = []
+
+    for subject_id in selected_subjects:
+        try:
+            path = subject_files[subject_id]
+        except KeyError as exc:  # pragma: no cover - guard for typos
+            raise KeyError(f"Subject {subject_id} is not present in the dataset") from exc
+
+        frame = _read_subject_file(path, drop_idle=drop_idle)
+        frame["subject_id"] = subject_id
+        frames.append(frame)
+
+    if not frames:
+        raise ValueError("No subject data loaded from the provided identifiers")
+
+    combined = pd.concat(frames, ignore_index=True)
+
+    required = {"timestamp", "activity_id", "subject_id"}
+    if columns is not None:
+        missing = set(columns) - set(PAMAP2_COLUMN_NAMES)
+        if missing:
+            raise KeyError(f"Columns {sorted(missing)} are not present in PAMAP2")
+        selected = list(required | set(columns))
+        combined = combined[selected]
+    else:
+        combined = combined[list(required | set(PAMAP2_COLUMN_NAMES))]
+
+    combined.sort_values(["subject_id", "timestamp"], inplace=True)
+    combined.reset_index(drop=True, inplace=True)
+
+    # Replace sentinel ``-1`` values with NaN so that later statistics ignore them.
+    combined.replace(-1.0, np.nan, inplace=True)
+
+    return combined
+
+
+def _window_indices(length: int, window_size: int, step: int) -> Iterable[Tuple[int, int]]:
+    if length < window_size:
+        return []
+    for start in range(0, length - window_size + 1, step):
+        yield start, start + window_size
+
+
+def summarise_windows(
+    frame: pd.DataFrame,
+    *,
+    window_size: int,
+    step: int,
+    feature_columns: Sequence[str] | None = None,
+) -> Pamap2WindowDataset:
+    """Turn a subject-wise DataFrame into windowed summary statistics."""
+
+    if feature_columns is None:
+        feature_columns = DEFAULT_SENSOR_COLUMNS
+
+    missing = set(feature_columns) - set(frame.columns)
+    if missing:
+        raise KeyError(f"Columns {sorted(missing)} are missing from the provided frame")
+
+    grouped = frame.groupby("subject_id", sort=True)
+
+    feature_vectors: List[List[float]] = []
+    labels: List[int] = []
+    provenance: List[Dict[str, object]] = []
+
+    for subject_id, subject_frame in grouped:
+        subject_values = subject_frame[feature_columns].to_numpy(dtype=float)
+        label_values = subject_frame["activity_id"].to_numpy(dtype=float)
+        timestamp_values = subject_frame["timestamp"].to_numpy(dtype=float)
+
+        for start, stop in _window_indices(len(subject_frame), window_size, step):
+            window = subject_values[start:stop]
+            label_window = label_values[start:stop]
+            timestamps = timestamp_values[start:stop]
+
+            stats: List[float] = []
+            for column_index in range(window.shape[1]):
+                column = window[:, column_index]
+                column = column[~np.isnan(column)]
+                if column.size == 0:
+                    mean = 0.0
+                    std = 0.0
+                else:
+                    mean = float(np.mean(column))
+                    std = float(np.std(column))
+                stats.extend([mean, std])
+
+            if np.all(np.isnan(label_window)):
+                continue
+
+            label_counts: MutableMapping[int, int] = {}
+            for raw_label in label_window:
+                if math.isnan(raw_label):
+                    continue
+                label = int(raw_label)
+                label_counts[label] = label_counts.get(label, 0) + 1
+
+            if not label_counts:
+                continue
+
+            dominant_label = max(label_counts.items(), key=lambda item: item[1])[0]
+
+            feature_vectors.append(stats)
+            labels.append(dominant_label)
+            provenance.append(
+                {
+                    "subject_id": int(subject_id),
+                    "start_timestamp": float(timestamps[0]),
+                    "stop_timestamp": float(timestamps[-1]),
+                }
+            )
+
+    if not feature_vectors:
+        raise ValueError("No windows could be generated with the provided configuration")
+
+    features_array = np.asarray(feature_vectors, dtype=float)
+    labels_array = np.asarray(labels, dtype=int)
+
+    metadata = {
+        "window_size": int(window_size),
+        "step": int(step),
+        "feature_columns": list(feature_columns),
+        "subjects": sorted({int(entry["subject_id"]) for entry in provenance}),
+        "windows": len(feature_vectors),
+        "provenance": provenance,
+    }
+
+    return Pamap2WindowDataset(features=features_array, labels=labels_array, metadata=metadata)
+
+
+def binarize_windows(
+    features: np.ndarray,
+    *,
+    thresholds: np.ndarray | None = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Convert window statistics to binary features for a Tsetlin Machine."""
+
+    if features.ndim != 2:
+        raise ValueError("Expected a 2D array of shape (n_samples, n_features)")
+
+    clean = np.nan_to_num(features, copy=True)
+
+    if thresholds is None:
+        thresholds = np.median(clean, axis=0)
+
+    binary = (clean >= thresholds).astype(int)
+    return binary, thresholds

--- a/docs/research/high_frequency_sensor_plan.md
+++ b/docs/research/high_frequency_sensor_plan.md
@@ -1,0 +1,83 @@
+# High-frequency Sensor Benchmark: PAMAP2 Activity Monitoring
+
+This note proposes the **PAMAP2 Physical Activity Monitoring** dataset as a
+foundation for comparing a Tsetlin Machine pipeline with transformer-style
+temporal models on dense wearable sensor streams. It consolidates the
+practical details needed to pull the data into this repository and summarises
+published transformer/LSTM results that can anchor a baseline section for a
+paper draft.
+
+## Dataset snapshot
+
+- **Domain:** multi-sensor human activity recognition collected from three
+  inertial measurement units (hand, chest, ankle) plus a heart-rate monitor.
+- **Sampling rate:** 100 Hz for the accelerometer/gyroscope/magnetometer
+  channels; the heart-rate stream is downsampled to roughly 9 Hz.
+- **Subjects & activities:** 9 participants performing 18 labeled activities
+  (daily living and sports), yielding ~12 hours of recordings.
+- **File layout:** each subject has a separate CSV file with synchronized sensor
+  channels and activity identifiers. The official splits separate train/test by
+  subject, which aligns with leave-one-subject-out evaluation used in the
+  literature.
+- **Availability:** downloadable from the
+  [UCI Machine Learning Repository](https://archive.ics.uci.edu/dataset/242/pamap2+physical+activity+monitoring)
+  or via mirrored Kaggle projects (e.g. `pamap2-physical-activity-monitoring`).
+  The original release is licensed for academic use, matching this prototype's
+  research focus.
+
+### Integration considerations
+
+1. **Storage footprint:** the full dataset is ~1.1 GB uncompressed. A minimal
+   subset (e.g. one IMU triplet plus heart rate) can be extracted to keep the
+   repository lightweight, while documentation can point to a reproducible
+   download script for full-scale experiments.
+2. **Preprocessing:** published baselines standardize per-channel, apply a
+   sliding window of 5.12 seconds (512 timesteps at 100 Hz) with 50% overlap,
+   and discard idle segments. Implementing the windowing pipeline alongside the
+   existing `examples/time_series_tsetlin.py` structure should allow quick
+   experimentation.
+3. **Label imbalance:** activities such as "rope jumping" are short, so
+   stratified batching or class weighting will help the Tsetlin configuration.
+
+## Established baselines to cite
+
+- **Transformer:** *HARFormer: Transformers-based Human Activity Recognition*
+  (Sensors, 2022) benchmarks a lightweight transformer encoder on PAMAP2,
+  reporting macro-F1 gains over convolutional and bi-directional LSTM baselines
+  under leave-one-subject-out evaluation. The architecture uses multi-head
+  self-attention on flattened sensor windows with positional encodings.
+- **LSTM:** The *DeepConvLSTM* architecture (Ordóñez & Roggen, 2016) remains a
+  strong recurrent baseline on PAMAP2, mixing convolutional feature extractors
+  with stacked LSTM layers. Later studies (e.g. the above HARFormer paper)
+  reproduce DeepConvLSTM as a comparison point, providing reference accuracy
+  values around the low-to-mid 90% macro-F1 range.
+- **Time-series transformer variants:** Follow-up work such as *Self-Supervised
+  Transformers for Wearable Activity Recognition* (Khedher et al., 2023)
+  explores masked modeling objectives on the same dataset, offering additional
+  pretraining baselines that we can mention when motivating future extensions.
+
+Collecting these references ensures that a "Related Work" or "Baseline"
+section in a paper draft can cite both transformer and LSTM results directly
+comparable to any Tsetlin Machine experiments executed within this repository.
+
+## Next steps for this repository
+
+1. **Data ingestion script:** add a utility (e.g. `scripts/download_pamap2.py`)
+   that fetches and unpacks the dataset, optionally trimming to a curated subset
+   for CI-friendly experiments. *(Update: `datasets/pamap2.py` now implements
+   runtime download and windowing helpers together with an executable example
+   in `examples/pamap2_tsetlin.py`.)*
+2. **Notebook or pipeline prototype:** adapt `examples/time_series_tsetlin.py`
+   to load the PAMAP2 windows and train a multiclass Tsetlin Machine, mirroring
+   the evaluation protocol from the transformer papers.
+3. **Result tracking:** extend `docs/time_series_outputs` with a PAMAP2 page
+   similar to the existing maritime and temperature scenarios. This will give us
+   a place to visualise accuracy curves and sample confusion matrices once the
+   experiments run.
+4. **Comparative analysis:** outline a reproducible transformer baseline
+   (PyTorch implementation of HARFormer or DeepConvLSTM) so the repo can produce
+   side-by-side metrics for the eventual paper.
+
+Keeping these tasks scoped and documented positions the project to articulate
+"how far off" the Tsetlin Machine is from state-of-the-art transformer
+approaches on high-frequency wearable sensor data.

--- a/examples/pamap2_tsetlin.py
+++ b/examples/pamap2_tsetlin.py
@@ -1,0 +1,197 @@
+"""Train a (surrogate) Tsetlin Machine on PAMAP2 activity windows.
+
+The script demonstrates how to combine the runtime download helpers from
+``datasets.pamap2`` with the perceptron-based ``MultiClassTsetlinMachine``
+shim bundled in this repository. It is intentionally lightweight so that the
+end-to-end workflow can execute on a laptop while still exercising the same
+code paths that a full experiment would use:
+
+* Download (or reuse) the PAMAP2 archive on demand.
+* Load subject-specific CSV files into a :class:`pandas.DataFrame`.
+* Generate sliding windows, summarise them, and binarise the statistics.
+* Train/test split by subject to respect the standard evaluation protocol.
+
+Usage example
+-------------
+::
+
+   python examples/pamap2_tsetlin.py \
+       --data-root ./data/pamap2 \
+       --train-subjects 101 103 105 \
+       --test-subjects 109 \
+       --epochs 10
+
+The defaults intentionally keep the configuration small. For real experiments,
+consider increasing the number of clauses, epochs, and the diversity of
+subjects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from datasets.pamap2 import (  # noqa: E402  - runtime path adjustment
+    DEFAULT_SENSOR_COLUMNS,
+    Pamap2WindowDataset,
+    binarize_windows,
+    ensure_pamap2_dataset,
+    load_pamap2_dataframe,
+    summarise_windows,
+)
+from pyTsetlinMachine.tm import MultiClassTsetlinMachine  # noqa: E402
+
+
+@dataclass
+class ExperimentConfig:
+    """Configuration parameters captured alongside the results."""
+
+    data_root: Path
+    train_subjects: Sequence[int]
+    test_subjects: Sequence[int]
+    window_size: int
+    step: int
+    clauses: int
+    threshold: int
+    specificity: float
+    epochs: int
+    feature_columns: Sequence[str]
+
+
+@dataclass
+class ExperimentResult:
+    """Lightweight container for serialising experiment outputs."""
+
+    config: ExperimentConfig
+    train_accuracy: float
+    test_accuracy: float
+    n_train_samples: int
+    n_test_samples: int
+
+    def to_json(self) -> str:
+        payload = {
+            "config": asdict(self.config),
+            "train_accuracy": self.train_accuracy,
+            "test_accuracy": self.test_accuracy,
+            "n_train_samples": self.n_train_samples,
+            "n_test_samples": self.n_test_samples,
+        }
+        return json.dumps(payload, indent=2)
+
+
+def _accuracy(predictions: Sequence[int], targets: Sequence[int]) -> float:
+    if not targets:
+        return float("nan")
+    correct = sum(int(p == t) for p, t in zip(predictions, targets))
+    return correct / len(targets)
+
+
+def _prepare_dataset(
+    data_root: Path,
+    subjects: Sequence[int],
+    *,
+    window_size: int,
+    step: int,
+    feature_columns: Sequence[str],
+    thresholds=None,
+) -> tuple[Pamap2WindowDataset, Sequence[int]]:
+    frame = load_pamap2_dataframe(data_root, subjects=subjects)
+    windows = summarise_windows(
+        frame,
+        window_size=window_size,
+        step=step,
+        feature_columns=feature_columns,
+    )
+    binary, thresholds_out = binarize_windows(windows.features, thresholds=thresholds)
+    windows = Pamap2WindowDataset(features=binary, labels=windows.labels, metadata=windows.metadata)
+    return windows, thresholds_out
+
+
+def main(argv: Sequence[str] | None = None) -> ExperimentResult:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=Path("./data/pamap2"),
+        help="Directory used to cache/download the PAMAP2 archive",
+    )
+    parser.add_argument("--train-subjects", nargs="*", default=[101, 103], type=int)
+    parser.add_argument("--test-subjects", nargs="*", default=[109], type=int)
+    parser.add_argument("--window-size", type=int, default=512)
+    parser.add_argument("--step", type=int, default=256)
+    parser.add_argument("--clauses", type=int, default=60)
+    parser.add_argument("--threshold", type=int, default=15)
+    parser.add_argument("--specificity", type=float, default=3.0)
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument(
+        "--feature-columns",
+        nargs="*",
+        default=list(DEFAULT_SENSOR_COLUMNS),
+        help="Optional override for the PAMAP2 sensor columns to summarise",
+    )
+
+    args = parser.parse_args(argv)
+
+    dataset_root = ensure_pamap2_dataset(args.data_root)
+
+    config = ExperimentConfig(
+        data_root=args.data_root,
+        train_subjects=args.train_subjects,
+        test_subjects=args.test_subjects,
+        window_size=args.window_size,
+        step=args.step,
+        clauses=args.clauses,
+        threshold=args.threshold,
+        specificity=args.specificity,
+        epochs=args.epochs,
+        feature_columns=tuple(args.feature_columns),
+    )
+
+    train_windows, thresholds = _prepare_dataset(
+        dataset_root,
+        args.train_subjects,
+        window_size=args.window_size,
+        step=args.step,
+        feature_columns=args.feature_columns,
+    )
+
+    test_windows, _ = _prepare_dataset(
+        dataset_root,
+        args.test_subjects,
+        window_size=args.window_size,
+        step=args.step,
+        feature_columns=args.feature_columns,
+        thresholds=thresholds,
+    )
+
+    model = MultiClassTsetlinMachine(args.clauses, args.threshold, args.specificity)
+    model.fit(train_windows.features.tolist(), train_windows.labels.tolist(), epochs=args.epochs)
+
+    train_predictions = model.predict(train_windows.features.tolist())
+    test_predictions = model.predict(test_windows.features.tolist())
+
+    train_accuracy = _accuracy(train_predictions, train_windows.labels.tolist())
+    test_accuracy = _accuracy(test_predictions, test_windows.labels.tolist())
+
+    result = ExperimentResult(
+        config=config,
+        train_accuracy=train_accuracy,
+        test_accuracy=test_accuracy,
+        n_train_samples=len(train_windows.labels),
+        n_test_samples=len(test_windows.labels),
+    )
+
+    print(result.to_json())
+    return result
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation entry-point
+    main()


### PR DESCRIPTION
## Summary
- add a reusable datasets.pamap2 module that downloads, loads, windows, and binarises PAMAP2 sensor streams on demand
- expose the helpers through a new pamap2_tsetlin example CLI that trains the surrogate Tsetlin Machine on subject-wise splits
- document the availability of the runtime pipeline from the planning note and project overview

## Testing
- python -m compileall datasets examples

------
https://chatgpt.com/codex/tasks/task_e_68e019faa2248324beb1acc7b950e73b